### PR TITLE
Add correlation plots for accuracy and warmth

### DIFF
--- a/analysis/report.qmd
+++ b/analysis/report.qmd
@@ -249,6 +249,28 @@ p1
 p2
 ```
 
+Does baseline accuracy correlate with baseline warmth? We examine whether people who are more biased about the outgroup also feel colder toward them.
+
+```{r baseline-accuracy-warmth-correlation}
+#| fig-width: 6
+#| fig-height: 4
+
+dat %>%
+  ggplot(aes(x = accuracy_pre, y = warmth_outgroup_pre, color = participant_party)) +
+  geom_point(alpha = 0.6, size = 2.5) +
+  geom_smooth(method = "lm", se = TRUE, linewidth = 1) +
+  stat_cor(aes(label = paste((..r.label..), ..p.label.., sep = "~`,`~")),
+           method = "pearson", show.legend = FALSE, size = 3.5) +
+  scale_color_manual(values = party_colors, name = "Political Party") +
+  labs(
+    title = "Relationship Between Baseline Accuracy and Warmth",
+    x = "Baseline Accuracy (Absolute Error)",
+    y = "Baseline Warmth (0-100 scale)"
+  ) +
+  theme_minimal() +
+  theme(plot.title = element_text(face = "bold"), legend.position = "bottom")
+```
+
 ### Q1. Do people update their beliefs after interacting with the chatbot?
 
 ```{r q1-data-prep}
@@ -322,6 +344,35 @@ modelsummary(
   coef_map = coef_map_common,
   notes = "Note: Accuracy is absolute error (lower = more accurate). * p<0.05, ** p<0.01, *** p<0.001"
 )
+```
+
+Do changes in accuracy correlate with changes in warmth? We examine whether people who became more accurate also became warmer toward the outgroup.
+
+```{r accuracy-warmth-change-correlation}
+#| fig-width: 6
+#| fig-height: 4
+
+# Create change scores for this analysis (reusing from later section)
+dat_with_changes <- dat %>%
+  mutate(
+    accuracy_change = accuracy_post - accuracy_pre,  # Negative = improvement
+    warmth_change = warmth_outgroup_post - warmth_outgroup_pre
+  )
+
+dat_with_changes %>%
+  ggplot(aes(x = accuracy_change, y = warmth_change, color = learner_party)) +
+  geom_point(alpha = 0.6, size = 2.5) +
+  geom_smooth(method = "lm", se = TRUE, linewidth = 1) +
+  stat_cor(aes(label = paste((..r.label..), ..p.label.., sep = "~`,`~")),
+           method = "pearson", show.legend = FALSE, size = 3.5) +
+  scale_color_manual(values = learner_party_colors, name = "Learner Party") +
+  labs(
+    title = "Relationship Between Accuracy Change and Warmth Change",
+    x = "Accuracy Change (Negative = Improvement)",
+    y = "Warmth Change (Positive = Increase)"
+  ) +
+  theme_minimal() +
+  theme(plot.title = element_text(face = "bold"), legend.position = "bottom")
 ```
 
 ### Q2. Is belief updating symmetric across political groups?


### PR DESCRIPTION
Added two correlation plots as requested:
1. Baseline accuracy vs warmth in preliminaries section (line 254-272)
   - Shows relationship between pre-interaction accuracy and warmth
   - Separate correlations for Democrats and Republicans
   - Uses stat_cor to display correlation coefficients

2. Accuracy change vs warmth change after main effect (line 351-376)
   - Shows relationship between changes in both measures
   - Separate correlations for D→R and R→D learner groups
   - Uses stat_cor to display correlation coefficients

Both plots follow the existing correlation plot pattern used elsewhere
in the report (e.g., bot empathy vs informativeness).