### PR TITLE
Fix GitHub issues #3, #4, and #5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@
 # Author: Benjamin Lira
 # Description: Reproducible pipeline for data processing and analysis
 
-.PHONY: all clean data analysis report help
+.PHONY: all clean data analysis report slides help
 
 # Default target: run entire pipeline
-all: report
+all: report slides
 
 # Help message
 help:
@@ -13,10 +13,11 @@ help:
 	@echo "========================================"
 	@echo ""
 	@echo "Available targets:"
-	@echo "  make all        - Run entire pipeline (download → clean → conversations → analysis → report)"
+	@echo "  make all        - Run entire pipeline (download → clean → conversations → analysis → report → slides)"
 	@echo "  make data       - Download raw data, clean it, and download conversations"
 	@echo "  make analysis   - Create analysis dataset"
 	@echo "  make report     - Render the report (HTML and PDF)"
+	@echo "  make slides     - Render the presentation slides (PDF)"
 	@echo "  make clean      - Remove all processed data and outputs"
 	@echo "  make help       - Show this help message"
 	@echo ""
@@ -42,6 +43,7 @@ clean:
 	rm -f output/extreme_cases_summary.md
 	rm -f analysis/report.html
 	rm -f analysis/report.pdf
+	rm -f analysis/slides.pdf
 	@echo "Clean complete!"
 
 # Step 0: Download raw Qualtrics data
@@ -118,9 +120,16 @@ analysis/report.pdf: analysis/report.qmd data/processed/cleaned_data.parquet dat
 report: report-html report-pdf
 	@echo "✓ All reports generated"
 	@echo ""
-	@echo "Pipeline complete! 🎉"
 	@echo "  - HTML: analysis/report.html"
 	@echo "  - PDF:  analysis/report.pdf"
+
+# Step 9: Render presentation slides
+slides: analysis/slides.pdf
+
+analysis/slides.pdf: analysis/slides.qmd data/processed/cleaned_data.parquet data/processed/conversation_metrics.parquet
+	@echo "Step 9: Rendering presentation slides..."
+	cd analysis && quarto render slides.qmd --to beamer
+	@echo "✓ Slides generated: analysis/slides.pdf"
 
 # Development: quick HTML-only render (faster for iteration)
 dev: data

--- a/analysis/report.qmd
+++ b/analysis/report.qmd
@@ -242,7 +242,8 @@ p2 <- dat %>%
   theme_minimal() +
   theme(
     plot.title = element_text(face = "bold"),
-    legend.position = "bottom"
+    legend.position = c(0.85, 0.85),
+    legend.background = element_rect(fill = "white", color = "gray80", linewidth = 0.3)
   )
 
 p1


### PR DESCRIPTION
Issue #3: Move legend to top-right inside distribution plot
- Changed legend.position from "bottom" to c(0.85, 0.85) in bias distribution plot
- Added white background with light gray border for better readability
- Legend now positioned in top-right corner inside the plot area

Issues #4 & #5: Add slides target to Makefile
- Added 'slides' target to render presentation slides from slides.qmd
- Updated .PHONY declaration to include slides
- Updated 'all' target to build both report and slides
- Updated help message to document slides target
- Updated clean target to remove slides.pdf
- Slides render as beamer PDF presentation

All changes maintain consistency with existing Makefile structure and follow the same dependency patterns as report targets.