### PR TITLE
Fix emmeans sign flip issue in simple effects tables

### DIFF
--- a/analysis/report.qmd
+++ b/analysis/report.qmd
@@ -403,12 +403,13 @@ dat_with_changes %>%
 
 ```{r}
 # Get simple effects
+# Note: reverse = TRUE ensures contrasts are computed as "post - pre" to match model coefficients
 accuracy_contrasts <- emmeans(accuracy_model, ~ time | learner_party) %>%
-  contrast("pairwise") %>%
+  pairs(reverse = TRUE) %>%
   tidy()
 
 warmth_contrasts <- emmeans(warmth_model, ~ time | learner_party) %>%
-  contrast("pairwise") %>%
+  pairs(reverse = TRUE) %>%
   tidy()
 
 # Extract values for inline reporting
@@ -528,13 +529,13 @@ high_extremism = extremism_mean + extremism_sd
 accuracy_extremism_contrasts <- emmeans(accuracy_extremism_model,
   ~ time | political_extremism,
   at = list(political_extremism = c(low_extremism, high_extremism))) %>%
-  contrast("pairwise") %>%
+  pairs(reverse = TRUE) %>%
   tidy()
 
 warmth_extremism_contrasts <- emmeans(warmth_extremism_model, ~ time | political_extremism,
 at = list(political_extremism = c(low_extremism, high_extremism))
 ) %>%
-  contrast("pairwise") %>%
+  pairs(reverse = TRUE) %>%
   tidy()
 
 # Format simple effects
@@ -807,7 +808,7 @@ confidence_model <- lmer(confidence ~ time * learner_party + (1 | ResponseId), d
 
 # Get simple effects for the interaction model
 confidence_contrasts <- emmeans(confidence_model, ~ time | learner_party) %>%
-  contrast("pairwise") %>%
+  pairs(reverse = TRUE) %>%
   tidy()
 
 # Extract values for inline reporting
@@ -1185,7 +1186,7 @@ warmth_diff_model <- lmer(warmth_diff ~ time * learner_party + (1 | ResponseId),
 
 # Get simple effects
 warmth_diff_contrasts <- emmeans(warmth_diff_model, ~ time | learner_party) %>%
-  contrast("pairwise") %>%
+  pairs(reverse = TRUE) %>%
   tidy()
 
 # Format simple effects

--- a/docs/emmeans_sign_fix.md
+++ b/docs/emmeans_sign_fix.md
@@ -1,0 +1,51 @@
+# Fix for emmeans Sign Flip Issue
+
+## Problem
+
+The simple effects tables in `report.qmd` were showing inconsistent signs between model coefficients and emmeans contrasts. This occurred because:
+
+1. **Model coefficients** (`timepost`): Represent `E[Y|time=post] - E[Y|time=pre]`
+   - For accuracy (error): Negative value = improvement (post < pre)
+   - For warmth: Positive value = increase (post > pre)
+
+2. **Default emmeans contrasts**: Computed `first_level - second_level`
+   - For `factor(c("pre", "post"))`: This computes `pre - post`
+   - Signs are **opposite** of model coefficients!
+
+## Solution
+
+Changed all emmeans contrast calculations from:
+```r
+emmeans(model, ~ time | group) %>%
+  contrast("pairwise") %>%
+  tidy()
+```
+
+To:
+```r
+emmeans(model, ~ time | group) %>%
+  pairs(reverse = TRUE) %>%
+  tidy()
+```
+
+The `reverse = TRUE` argument makes emmeans compute `post - pre` instead of `pre - post`, matching the model coefficient direction.
+
+## Files Modified
+
+- `analysis/report.qmd`: Fixed 4 instances of emmeans contrasts:
+  - Q2: Accuracy and warmth contrasts by learner_party (lines 407-413)
+  - Q3: Accuracy and warmth contrasts by extremism level (lines 529-539)
+  - Q7: Confidence contrasts by learner_party (lines 810-812)
+  - Robustness: Warmth difference contrasts (lines 1188-1190)
+
+## Verification
+
+After this fix:
+- Model coefficients and emmeans contrasts have **consistent signs**
+- Tables showing both regression results and simple effects are now **internally consistent**
+- Negative accuracy values = improvement (error decreases)
+- Positive warmth values = increase (feelings warmer)
+
+## Technical Details
+
+The `pairs()` function with `reverse = TRUE` is equivalent to `contrast(method = "revpairwise")`. Both reverse the default comparison direction to compute second_level - first_level instead of first_level - second_level.


### PR DESCRIPTION
Problem: emmeans contrasts were computing pre-post instead of post-pre,
causing sign inconsistencies with model coefficients in tables.

Solution: Added reverse=TRUE to all pairs() calls in emmeans contrasts
to match model coefficient direction (post - pre).

Changes:
- Fixed 4 instances of emmeans contrasts in report.qmd
- Added documentation explaining the fix in docs/emmeans_sign_fix.md

Now model coefficients and emmeans simple effects have consistent signs:
- Negative accuracy = improvement (error decreases)
- Positive warmth = increase (feelings warmer)